### PR TITLE
Fix release uploads to avoid deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,6 @@ jobs:
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -o "$NAME" .
           echo "ASSET_NAME=$NAME" >> $GITHUB_ENV
       - name: Upload binary
-        uses: actions/upload-release-asset@v1.0.2
+        run: gh release upload "${{ github.ref_name }}" "${{ env.ASSET_NAME }}" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.ASSET_NAME }}
-          asset_name: ${{ env.ASSET_NAME }}
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- upload release assets using `gh release upload`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68502cbbfb7483289f8169cedae40fa5