### PR TITLE
Add base directory option for verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ CheckSumFolder -dir /path/to/dir -out hashes.txt -progress
 ```
 CheckSumFolder -verify -dir /path/to/dir -list hashes.txt [-verbose]
 ```
+The `-dir` flag specifies the folder containing the files to verify. Each line
+in `hashes.txt` may contain absolute paths from a different system; only the
+file name is used when constructing the path under `-dir`.
 Use `-verbose` to print the status of every file. Without it, only mismatches
 are printed or a message that everything matches. Add `-progress` to show
 verification progress. Verification runs in parallel across all CPU cores to


### PR DESCRIPTION
## Summary
- allow verifying hashes when file paths differ across systems
- update README with new verification explanation

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685040ca074c8328aaa05080313946c0