### PR TITLE
Add cross-platform path handling for verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ CheckSumFolder -dir /path/to/dir -out hashes.txt -progress
 ```
 CheckSumFolder -verify -dir /path/to/dir -list hashes.txt [-verbose]
 ```
+The `-dir` flag specifies the folder containing the files to verify. Each line
+in `hashes.txt` may contain absolute paths from a different system. During
+verification the tool ignores directories and path separators, using only the
+file name from the list when building the full path under `-dir`.
 Use `-verbose` to print the status of every file. Without it, only mismatches
 are printed or a message that everything matches. Add `-progress` to show
 verification progress. Verification runs in parallel across all CPU cores to

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -125,6 +126,7 @@ func generateChecksums(dir, output string, progress bool) error {
 
 func verifyChecksums(dir, listfile string, verbose, progress bool) error {
 	expected := map[string]string{}
+	var paths []string
 	f, err := os.Open(listfile)
 	if err != nil {
 		return err
@@ -134,27 +136,16 @@ func verifyChecksums(dir, listfile string, verbose, progress bool) error {
 		line := scanner.Text()
 		parts := strings.SplitN(line, "\t", 2)
 		if len(parts) == 2 {
-			expected[parts[1]] = parts[0]
+			p := strings.ReplaceAll(parts[1], "\\", "/")
+			name := path.Base(p)
+			expected[name] = parts[0]
+			paths = append(paths, name)
 		}
 	}
 	f.Close()
 
 	var match, mismatch int
 
-	var paths []string
-	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		paths = append(paths, path)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
 	total := len(paths)
 	var processedCount int64
 
@@ -173,8 +164,9 @@ func verifyChecksums(dir, listfile string, verbose, progress bool) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for path := range jobs {
-				exp, ok := expected[path]
+			for name := range jobs {
+				path := filepath.Join(dir, name)
+				exp, ok := expected[name]
 				hash, hErr := hashFile(path)
 				r := result{path: path}
 				if hErr != nil {


### PR DESCRIPTION
## Summary
- adjust README explanation for how verification uses filenames
- normalize Windows-style paths during verification

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685040ca074c8328aaa05080313946c0