### PR TITLE
Fix build by removing unused path import

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"


### PR DESCRIPTION
## Summary
- remove unused `path` import to fix build error

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68504ce43c7083289f5b96d03572a5df