### PR TITLE
Change output flag to -list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ against a previously generated list of hashes.
 
 ### Generate checksums
 ```
-CheckSumFolder -dir /path/to/dir -out hashes.txt
+CheckSumFolder -dir /path/to/dir [-list hashes.txt]
 ```
-If `hashes.txt` already contains results, existing entries are skipped so the
+If `-list` is omitted the results are printed to the console. When a file is
+specified and it already contains results, existing entries are skipped so the
 operation can be resumed.
 
 Use `-progress` to periodically print how many files have been processed.
 
-Example:
+Example writing to a file:
 ```
-CheckSumFolder -dir /path/to/dir -out hashes.txt -progress
+CheckSumFolder -dir /path/to/dir -list hashes.txt -progress
 ```
 
 ### Verify checksums


### PR DESCRIPTION
## Summary
- unify flag name `-list` for both hashing and verification
- print hashes to console if `-list` is omitted
- update README with new flag usage

## Testing
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_685125a71248832885aca33298092528