### PR TITLE
Add configurable hashing algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
 # CheckSumFolder
 
 CheckSumFolder is a command line tool written in Go that scans a directory
-recursively, computes the SHA1 checksum of every file and writes the results to
-an output text file. The tool can resume interrupted runs and also verify files
-against a previously generated list of hashes.
+recursively, computes checksums of every file and writes the results to an
+output text file. The tool can resume interrupted runs and also verify files
+against a previously generated list of hashes. By default SHA1 is used but the
+hash algorithm can be changed.
 
 ## Usage
 
 ### Generate checksums
 ```
-CheckSumFolder -dir /path/to/dir [-list hashes.txt]
+CheckSumFolder -dir /path/to/dir [-list hashes.txt] [-hash sha256]
 ```
 If `-list` is omitted the results are printed to the console. When a file is
 specified and it already contains results, existing entries are skipped so the
-operation can be resumed.
+operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
+values are `sha1`, `sha256`, `blake3` and `xxhash`.
 
 
 ## TODO
 
 - add option to save to jsol format
-- add option to change hash type crc32/md5/sha1/sha256/blake3/etc
 Use `-progress` to periodically print how many files have been processed.
 Use `-json` to write results in JSONL format where each line is a JSON object
 containing `hash` and `path` fields.
@@ -50,7 +51,3 @@ Example:
 ```
 CheckSumFolder -verify -dir /path/to/dir -list hashes.txt -progress
 ```
-
-## TODO
-
-- add option to change hash type crc32/md5/sha1/sha256/blake3/etc

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module CheckSumFolder
 
 go 1.23.8
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/minio/sha256-simd v1.0.1
+	github.com/zeebo/blake3 v0.2.4
+)
+
+require (
+	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
+	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
+github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Summary
- add flag to select hashing algorithm
- support sha256-simd, blake3 and xxhash
- document new `-hash` flag and algorithms

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ae696f0608328b01ee4f82c317350