### PR TITLE
Add CPU feature detection with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ Example:
 ```
 CheckSumFolder -verify -dir /path/to/dir -list hashes.txt -progress
 ```
+
+### CPU Optimizations
+
+ChecksumFolder detects available CPU features using the
+[`cpuid`](https://github.com/klauspost/cpuid) library. When SIMD
+instructions like SSE2 on x86 or ASIMD/NEON on ARM64 are present the
+program uses the accelerated `sha256-simd` implementation. On older
+CPUs without these capabilities it transparently falls back to Go's
+standard SHA-256 implementation. This happens automatically at
+startup and works across different architectures.

--- a/cpu_opt.go
+++ b/cpu_opt.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"runtime"
+
+	cpuid "github.com/klauspost/cpuid/v2"
+)
+
+var useStdSHA256 bool
+
+func init() {
+	// On ARM64 some features require explicit detection
+	if runtime.GOARCH == "arm64" {
+		cpuid.DetectARM()
+	}
+
+	// Fallback to the standard crypto/sha256 if we lack SIMD features
+	switch runtime.GOARCH {
+	case "amd64", "386":
+		if !cpuid.CPU.Supports(cpuid.SSE2) {
+			useStdSHA256 = true
+		}
+	case "arm64":
+		if !cpuid.CPU.Supports(cpuid.ASIMD) {
+			useStdSHA256 = true
+		}
+	default:
+		// Unknown architecture, use conservative default
+		useStdSHA256 = true
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,9 @@ go 1.23.8
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/klauspost/cpuid/v2 v2.2.3
 	github.com/minio/sha256-simd v1.0.1
 	github.com/zeebo/blake3 v0.2.4
 )
 
-require (
-	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
-	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
-)
+require golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"crypto/sha1"
+	stdsha256 "crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -338,7 +339,11 @@ func hashFile(path, algo string) (string, error) {
 	case "sha1":
 		h = sha1.New()
 	case "sha256":
-		h = sha256.New()
+		if useStdSHA256 {
+			h = stdsha256.New()
+		} else {
+			h = sha256.New()
+		}
 	case "blake3":
 		h = blake3.New()
 	case "xxhash":


### PR DESCRIPTION
## Summary
- add dynamic CPU feature detection via `cpuid`
- fall back to the standard `crypto/sha256` when SIMD isn't available
- document CPU optimizations in README

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bd42b71e48328b5c93d4031c90254