### PR TITLE
Fix missing sha256-simd import

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	sha256 "github.com/minio/sha256-simd"
 	"github.com/zeebo/blake3"
 	"hash"
 )
@@ -366,7 +367,7 @@ func hashFile(path, algo string) (string, error) {
 		h = sha1.New()
 	case "sha256":
 		if useStdSHA256 {
-      h = stdsha256.New()
+			h = stdsha256.New()
 		} else {
 			h = sha256.New()
 		}


### PR DESCRIPTION
## Summary
- restore `github.com/minio/sha256-simd` import so sha256 hashing works

## Testing
- `go vet ./...`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_686bf3575fb483289c7aeaf3a53b74e6