### PR TITLE
Add HighwayHash options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CheckSumFolder -dir /path/to/dir [-list hashes.txt] [-hash sha256]
 If `-list` is omitted the results are printed to the console. When a file is
 specified and it already contains results, existing entries are skipped so the
 operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
-values are `sha1`, `sha256`, `blake3` and `xxhash`.
+values are `sha1`, `sha256`, `blake3`, `xxhash`, `highway64`, `highway128` and `highway256`.
 
 
 ## TODO
@@ -57,7 +57,8 @@ CheckSumFolder -verify -dir /path/to/dir -list hashes.txt -progress
 ChecksumFolder detects available CPU features using the
 [`cpuid`](https://github.com/klauspost/cpuid) library. When SIMD
 instructions like SSE2 on x86 or ASIMD/NEON on ARM64 are present the
-program uses the accelerated `sha256-simd` implementation. On older
-CPUs without these capabilities it transparently falls back to Go's
-standard SHA-256 implementation. This happens automatically at
-startup and works across different architectures.
+program uses the accelerated `sha256-simd` implementation.
+HighwayHash also ships optimized assembly for Intel and ARM CPUs.
+On older CPUs without these capabilities it transparently falls back to Go's
+standard implementations. This happens automatically at startup and
+works across different architectures.

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.23.8
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/klauspost/cpuid/v2 v2.2.3
+	github.com/minio/highwayhash v1.0.3
 	github.com/minio/sha256-simd v1.0.1
 	github.com/zeebo/blake3 v0.2.4
 )
 
-require golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
+github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
@@ -10,5 +12,6 @@ github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
 github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
 github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
## Summary
- support new hash algorithms via `github.com/minio/highwayhash`
- document new algorithms and optimized CPU support

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cd453244483288c2290e970a784a8