### PR TITLE
Add hkey flag to specify HighwayHash key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ If `-list` is omitted the results are printed to the console. When a file is
 specified and it already contains results, existing entries are skipped so the
 operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
 values are `sha1`, `sha256`, `blake3`, `xxhash`, `highway64`, `highway128` and `highway256`.
+When using a HighwayHash variant you can provide a custom key via the `-hkey`
+flag. The key must be 32 bytes encoded as hex or base64. If omitted a fixed
+test key is used.
 
 
 ## TODO
@@ -46,6 +49,7 @@ are printed or a message that everything matches. Add `-progress` to show
 verification progress. Verification runs in parallel across all CPU cores to
 speed up processing on large directory trees.
 Use `-json` when verifying to read the checksum list in JSONL format.
+When verifying with a HighwayHash algorithm pass the same key using `-hkey`.
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ specified and it already contains results, existing entries are skipped so the
 operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
 values are `sha1`, `sha256`, `blake3`, `xxhash`, `highway64`, `highway128` and `highway256`.
 When using a HighwayHash variant you can provide a custom key via the `-hkey`
-flag. The key must be 32 bytes encoded as hex or base64. If omitted a fixed
-test key is used.
+flag. The key must be 32 bytes encoded as hex or base64. If omitted the
+default key `AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=` (base64) is used.
 
 
 ## TODO
@@ -49,7 +49,8 @@ are printed or a message that everything matches. Add `-progress` to show
 verification progress. Verification runs in parallel across all CPU cores to
 speed up processing on large directory trees.
 Use `-json` when verifying to read the checksum list in JSONL format.
-When verifying with a HighwayHash algorithm pass the same key using `-hkey`.
+When verifying with a HighwayHash algorithm pass the same key using `-hkey`. If
+the flag is omitted the same default key is assumed.
 
 Example:
 ```

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ var highwayKey = []byte{
 	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
 }
 
+const defaultHighwayKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
 func main() {
 	dir := flag.String("dir", ".", "directory to scan")
 	list := flag.String("list", "", "checksum list file")
@@ -41,24 +43,22 @@ func main() {
 	verbose := flag.Bool("verbose", false, "verbose verify output")
 	progress := flag.Bool("progress", false, "show progress updates")
 	jsonl := flag.Bool("json", false, "output in JSONL format")
-	hkeyFlag := flag.String("hkey", "", "hex or base64 HighwayHash key")
+	hkeyFlag := flag.String("hkey", defaultHighwayKey, "hex or base64 HighwayHash key")
 	algo := flag.String("hash", "sha1", "hash algorithm: sha1|sha256|blake3|xxhash|highway64|highway128|highway256")
 	flag.Parse()
 
-	if *hkeyFlag != "" {
-		if k, err := hex.DecodeString(*hkeyFlag); err == nil {
-			if len(k) != 32 {
-				log.Fatal("highwayhash key must be 32 bytes")
-			}
-			highwayKey = k
-		} else if k, err := base64.StdEncoding.DecodeString(*hkeyFlag); err == nil {
-			if len(k) != 32 {
-				log.Fatal("highwayhash key must be 32 bytes")
-			}
-			highwayKey = k
-		} else {
-			log.Fatal("invalid hkey encoding")
+	if k, err := hex.DecodeString(*hkeyFlag); err == nil {
+		if len(k) != 32 {
+			log.Fatal("highwayhash key must be 32 bytes")
 		}
+		highwayKey = k
+	} else if k, err := base64.StdEncoding.DecodeString(*hkeyFlag); err == nil {
+		if len(k) != 32 {
+			log.Fatal("highwayhash key must be 32 bytes")
+		}
+		highwayKey = k
+	} else {
+		log.Fatal("invalid hkey encoding")
 	}
 
 	if *verify {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha1"
 	stdsha256 "crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -40,8 +41,25 @@ func main() {
 	verbose := flag.Bool("verbose", false, "verbose verify output")
 	progress := flag.Bool("progress", false, "show progress updates")
 	jsonl := flag.Bool("json", false, "output in JSONL format")
+	hkeyFlag := flag.String("hkey", "", "hex or base64 HighwayHash key")
 	algo := flag.String("hash", "sha1", "hash algorithm: sha1|sha256|blake3|xxhash|highway64|highway128|highway256")
 	flag.Parse()
+
+	if *hkeyFlag != "" {
+		if k, err := hex.DecodeString(*hkeyFlag); err == nil {
+			if len(k) != 32 {
+				log.Fatal("highwayhash key must be 32 bytes")
+			}
+			highwayKey = k
+		} else if k, err := base64.StdEncoding.DecodeString(*hkeyFlag); err == nil {
+			if len(k) != 32 {
+				log.Fatal("highwayhash key must be 32 bytes")
+			}
+			highwayKey = k
+		} else {
+			log.Fatal("invalid hkey encoding")
+		}
+	}
 
 	if *verify {
 		if *list == "" {


### PR DESCRIPTION
## Summary
- introduce `-hkey` flag that accepts hex or base64 encoded HighwayHash key
- document the new flag in README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ce49194a88328a9553dce4e6107a3