### PR TITLE
Add blake2b-simd hash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CheckSumFolder -dir /path/to/dir [-list hashes.txt] [-hash sha256]
 If `-list` is omitted the results are printed to the console. When a file is
 specified and it already contains results, existing entries are skipped so the
 operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
-values are `sha1`, `sha256`, `blake3`, `xxhash`, `xxh3`, `xxh128`, `t1ha1`, `t1ha2`, `highway64`, `highway128` and `highway256`.
+values are `sha1`, `sha256`, `blake2b`, `blake3`, `xxhash`, `xxh3`, `xxh128`, `t1ha1`, `t1ha2`, `highway64`, `highway128` and `highway256`.
 When using a HighwayHash variant you can provide a custom key via the `-hkey`
 flag. The key must be 32 bytes encoded as hex or base64. If omitted the
 default key `AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=` (base64) is used.
@@ -63,7 +63,9 @@ CheckSumFolder -verify -dir /path/to/dir -list hashes.txt -progress
 ChecksumFolder detects available CPU features using the
 [`cpuid`](https://github.com/klauspost/cpuid) library. When SIMD
 instructions like SSE2 on x86 or ASIMD/NEON on ARM64 are present the
-program uses the accelerated `sha256-simd` implementation.
+program uses the accelerated `sha256-simd` implementation. `blake2b-simd`
+also provides optimized AVX2 and NEON assembly which is selected
+automatically when supported.
 HighwayHash also ships optimized assembly for x86 and ARM64 CPUs. The
 `xxh3`/`xxh128` implementations detect AVX2 or NEON at runtime and use
 vectorized code when available. The `t1ha` routines include tuned

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.8
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/klauspost/cpuid/v2 v2.2.3
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/highwayhash v1.0.3
 	github.com/minio/sha256-simd v1.0.1
 	github.com/zeebo/blake3 v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
+github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	blake2b "github.com/minio/blake2b-simd"
 	"github.com/minio/highwayhash"
 	sha256 "github.com/minio/sha256-simd"
 	"github.com/zeebo/blake3"
@@ -48,7 +49,7 @@ func main() {
 	progress := flag.Bool("progress", false, "show progress updates")
 	jsonl := flag.Bool("json", false, "output in JSONL format")
 	hkeyFlag := flag.String("hkey", defaultHighwayKey, "hex or base64 HighwayHash key")
-	algo := flag.String("hash", "sha1", "hash algorithm: sha1|sha256|blake3|xxhash|xxh3|xxh128|t1ha1|t1ha2|highway64|highway128|highway256")
+	algo := flag.String("hash", "sha1", "hash algorithm: sha1|sha256|blake2b|blake3|xxhash|xxh3|xxh128|t1ha1|t1ha2|highway64|highway128|highway256")
 	flag.Parse()
 
 	if k, err := hex.DecodeString(*hkeyFlag); err == nil {
@@ -423,6 +424,8 @@ func hashFile(path, algo string) (string, error) {
 		} else {
 			h = sha256.New()
 		}
+	case "blake2b":
+		h = blake2b.New512()
 	case "blake3":
 		h = blake3.New()
 	case "xxhash":


### PR DESCRIPTION
## Summary
- add `github.com/minio/blake2b-simd` dependency
- support `blake2b` hashing option in CLI
- mention blake2b-simd in documentation

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d18f3c3e08328a763ff7938d5519e