### PR TITLE
Expand GitHub Actions build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,36 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
         include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
           - goos: linux
             goarch: arm
             goarm: 7
+          - goos: linux
+            goarch: ppc64le
+          - goos: linux
+            goarch: s390x
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+          - goos: windows
+            goarch: 386
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: freebsd
+            goarch: amd64
+          - goos: freebsd
+            goarch: arm64
+          - goos: openbsd
+            goarch: amd64
+          - goos: netbsd
+            goarch: amd64
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
## Summary
- expand the release workflow to target additional platforms and architectures

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d350120e88328a8d57c5542096b56