### PR TITLE
Enable CGO cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,44 +24,62 @@ jobs:
   build:
     needs: create_release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: linux
-            goarch: arm
-            goarm: 7
-          - goos: linux
-            goarch: ppc64le
-          - goos: linux
-            goarch: s390x
-          - goos: windows
-            goarch: amd64
-          - goos: windows
-            goarch: arm64
-          - goos: windows
-            goarch: 386
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: freebsd
-            goarch: amd64
-          - goos: freebsd
-            goarch: arm64
-          - goos: openbsd
-            goarch: amd64
-          - goos: netbsd
-            goarch: amd64
+      strategy:
+        matrix:
+          include:
+            - goos: linux
+              goarch: amd64
+              zig: x86_64-linux-gnu
+            - goos: linux
+              goarch: arm64
+              zig: aarch64-linux-gnu
+            - goos: linux
+              goarch: arm
+              goarm: 7
+              zig: armv7-linux-gnueabihf
+            - goos: linux
+              goarch: ppc64le
+              zig: powerpc64le-linux-gnu
+            - goos: linux
+              goarch: s390x
+              zig: s390x-linux-gnu
+            - goos: windows
+              goarch: amd64
+              zig: x86_64-windows-gnu
+            - goos: windows
+              goarch: arm64
+              zig: aarch64-windows-gnu
+            - goos: windows
+              goarch: 386
+              zig: i386-windows-gnu
+            - goos: darwin
+              goarch: amd64
+              zig: x86_64-macos
+            - goos: darwin
+              goarch: arm64
+              zig: aarch64-macos
+            - goos: freebsd
+              goarch: amd64
+              zig: x86_64-freebsd
+            - goos: freebsd
+              goarch: arm64
+              zig: aarch64-freebsd
+            - goos: openbsd
+              goarch: amd64
+              zig: x86_64-openbsd
+            - goos: netbsd
+              goarch: amd64
+              zig: x86_64-netbsd
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.23.x'
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 'latest'
       - name: Build binary
         run: |
           NAME=CheckSumFolder-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -71,6 +89,9 @@ jobs:
           if [ "${{ matrix.goos }}" = "windows" ]; then
             NAME="$NAME.exe"
           fi
+          export CGO_ENABLED=1
+          export CC="zig cc -target ${{ matrix.zig }}"
+          export CXX="zig c++ -target ${{ matrix.zig }}"
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -o "$NAME" .
           echo "ASSET_NAME=$NAME" >> $GITHUB_ENV
       - name: Upload binary


### PR DESCRIPTION
## Summary
- build all targets with CGO enabled by installing Zig and using it to cross compile

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d6ceda6c08328b8238cae503785b0