### PR TITLE
Fix Zig installer version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,7 @@ jobs:
         with:
           go-version: '1.23.x'
       - name: Set up Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 'master'
+        uses: mlugg/setup-zig@v2.0.4
       - name: Build binary
         run: |
           NAME=CheckSumFolder-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
## Summary
- update `mlugg/setup-zig` to stable v2.0.4
- rely on default Zig version

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e41e5f6d08328a94bad2e49ec2868