### PR TITLE
Fix blake3c build tag

### DIFF
--- a/blake3c/blake3c.go
+++ b/blake3c/blake3c.go
@@ -5,8 +5,8 @@ package blake3c
 /*
 #cgo CFLAGS: -O3 -std=c99 -fno-stack-protector -fPIC
 #cgo amd64 CFLAGS: -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512
-#cgo arm64 CFLAGS: -DBLAKE3_USE_NEON
-#cgo arm CFLAGS: -DBLAKE3_USE_NEON -mfpu=neon-vfpv4
+#cgo arm64 CFLAGS: -DBLAKE3_USE_NEON -mcpu=cortex-a53
+#cgo arm CFLAGS: -DBLAKE3_USE_NEON -mcpu=cortex-a7 -mfpu=neon
 #include "blake3.h"
 #include "blake3_impl.h"
 #include "lib/blake3.c"

--- a/blake3c/blake3c_stub.go
+++ b/blake3c/blake3c_stub.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo || (!amd64 && !arm64 && !arm)
 
 package blake3c
 

--- a/rapidhashc/rapidhashc.go
+++ b/rapidhashc/rapidhashc.go
@@ -5,8 +5,8 @@ package rapidhashc
 /*
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
-#cgo arm64 CFLAGS: -march=armv8-a+simd
-#cgo arm CFLAGS: -mfpu=neon
+#cgo arm64 CFLAGS: -mcpu=cortex-a53
+#cgo arm CFLAGS: -mcpu=cortex-a7 -mfpu=neon
 #include "rapidhash.h"
 
 static inline uint64_t rapidhash_go(const void* data, size_t len) {

--- a/wyhashc/wyhashc.go
+++ b/wyhashc/wyhashc.go
@@ -5,8 +5,8 @@ package wyhashc
 /*
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
-#cgo arm64 CFLAGS: -march=armv8-a+simd
-#cgo arm CFLAGS: -mfpu=neon
+#cgo arm64 CFLAGS: -mcpu=cortex-a53
+#cgo arm CFLAGS: -mcpu=cortex-a7 -mfpu=neon
 #include "wyhash.h"
 
 static inline uint64_t wyhash_go(const void* data, size_t len) {


### PR DESCRIPTION
## Summary
- widen build constraints for `blake3c` stub so unsupported architectures compile when CGO is enabled
- use generic ARM CPU names for C flags so cross compilation with Zig works

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e75ffb4b88328a4fde1c77ae58d0a