### PR TITLE
Fix cross-build errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
             zig: aarch64-windows-gnu
           - goos: windows
             goarch: 386
-            zig: i386-windows-gnu
+            zig: x86-windows-gnu
           - goos: darwin
             goarch: amd64
             zig: x86_64-macos
@@ -87,9 +87,13 @@ jobs:
           if [ "${{ matrix.goos }}" = "windows" ]; then
             NAME="$NAME.exe"
           fi
-          export CGO_ENABLED=1
-          export CC="zig cc -target ${{ matrix.zig }}"
-          export CXX="zig c++ -target ${{ matrix.zig }}"
+          if [ "${{ matrix.goos }}" = "freebsd" ]; then
+            export CGO_ENABLED=0
+          else
+            export CGO_ENABLED=1
+            export CC="zig cc -target ${{ matrix.zig }}"
+            export CXX="zig c++ -target ${{ matrix.zig }}"
+          fi
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -o "$NAME" .
           echo "ASSET_NAME=$NAME" >> $GITHUB_ENV
       - name: Upload binary


### PR DESCRIPTION
## Summary
- correct Zig target for 32-bit Windows builds
- disable CGO for FreeBSD builds so that headers are not required

## Testing
- `go vet ./...`
- `go build ./...`
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_686e9ab7c13c8328976dfa8aa5638a29