### PR TITLE
Fix cross-build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: 7
-            zig: armv7-linux-gnueabihf
+            zig: arm-linux-gnueabihf
           - goos: linux
             goarch: ppc64le
             zig: powerpc64le-linux-gnu
@@ -87,13 +87,17 @@ jobs:
           if [ "${{ matrix.goos }}" = "windows" ]; then
             NAME="$NAME.exe"
           fi
-          if [ "${{ matrix.goos }}" = "freebsd" ]; then
-            export CGO_ENABLED=0
-          else
-            export CGO_ENABLED=1
-            export CC="zig cc -target ${{ matrix.zig }}"
-            export CXX="zig c++ -target ${{ matrix.zig }}"
-          fi
+          case "${{ matrix.goos }}" in
+            linux|windows)
+              export CGO_ENABLED=1
+              export CC="zig cc -target ${{ matrix.zig }}"
+              export CXX="zig c++ -target ${{ matrix.zig }}"
+              ;;
+            *)
+              # Cross-compiling to other operating systems uses the pure Go fallback
+              export CGO_ENABLED=0
+              ;;
+          esac
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} go build -o "$NAME" .
           echo "ASSET_NAME=$NAME" >> $GITHUB_ENV
       - name: Upload binary

--- a/blake3c/blake3c.go
+++ b/blake3c/blake3c.go
@@ -5,7 +5,7 @@ package blake3c
 /*
 #cgo CFLAGS: -O3 -std=c99 -fno-stack-protector -fPIC
 #cgo amd64 CFLAGS: -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512
-#cgo arm64 CFLAGS: -DBLAKE3_USE_NEON -mcpu=cortex-a53
+#cgo arm64 CFLAGS: -DBLAKE3_USE_NEON
 #cgo arm CFLAGS: -DBLAKE3_USE_NEON -mcpu=cortex-a7 -mfpu=neon
 #include "blake3.h"
 #include "blake3_impl.h"

--- a/rapidhashc/rapidhashc.go
+++ b/rapidhashc/rapidhashc.go
@@ -5,7 +5,7 @@ package rapidhashc
 /*
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
-#cgo arm64 CFLAGS: -mcpu=cortex-a53
+#cgo arm64 CFLAGS:
 #cgo arm CFLAGS: -mcpu=cortex-a7 -mfpu=neon
 #include "rapidhash.h"
 

--- a/wyhashc/wyhashc.go
+++ b/wyhashc/wyhashc.go
@@ -5,7 +5,7 @@ package wyhashc
 /*
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
-#cgo arm64 CFLAGS: -mcpu=cortex-a53
+#cgo arm64 CFLAGS:
 #cgo arm CFLAGS: -mcpu=cortex-a7 -mfpu=neon
 #include "wyhash.h"
 


### PR DESCRIPTION
## Summary
- adjust zig target for linux/arm builds
- enable CGO on Windows builds
- disable CGO for other cross-compiles
- compile arm64 C code with generic flags

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686edc218cc8832892dad3e06aa2fd82