### PR TITLE
Print elapsed time when progress enabled and disable cgo on armv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ hash algorithm can be changed.
 
 ### Build Requirements
 Building with NEON support requires CGO enabled and a working C compiler.
+On 32-bit ARM (armv7) the C and C++ implementations are disabled and the
+program always uses pure Go fallbacks.
 
 ## Usage
 
@@ -28,7 +30,7 @@ HighwayHash assembly accelerates only x86 and ARM64 platforms.
 ## TODO
 
 - add option to save to jsol format
-Use `-progress` to periodically print how many files have been processed.
+Use `-progress` to periodically print how many files have been processed. When enabled, the total time taken is printed after completion.
 Use `-json` to write results in JSONL format where each line is a JSON object
 containing `hash` and `path` fields.
 
@@ -50,7 +52,7 @@ allows verifying files across machines even when the root folders differ.
 
 Use `-verbose` to print the status of every file. Without it, only mismatches
 are printed or a message that everything matches. Add `-progress` to show
-verification progress. Verification runs in parallel across all CPU cores to
+verification progress. When enabled, the total time taken is printed after completion. Verification runs in parallel across all CPU cores to
 speed up processing on large directory trees.
 Use `-json` when verifying to read the checksum list in JSONL format.
 When verifying with a HighwayHash algorithm pass the same key using `-hkey`. If
@@ -75,13 +77,15 @@ vectorized code when available. The `t1ha` routines include tuned
 implementations with optional AES and NEON support and fall back to
 portable code on other CPUs. No official armv7 assembly is provided.
 Wyhash and its successor `rapidhash` can use optional C wrappers
-compiled with `-msse2` on Intel or `-mfpu=neon` on ARM. When CGO is
+compiled with `-msse2` on Intel or `-mfpu=neon` on ARM64. When CGO is
 enabled and the CPU supports these features, the program calls the C
 implementation for additional speed. Otherwise the pure Go fallback is
-used automatically.
+used automatically. On 32-bit ARM (armv7) these C paths are disabled and
+the pure Go implementations are always used.
 When NEON is detected the program also uses the official BLAKE3 C
-implementation via CGO for additional performance. A working C toolchain
-is required in this case.
+implementation via CGO for additional performance. The C implementation
+is not built on armv7 where the pure Go version is used. A working C
+toolchain is required in this case.
 On older CPUs without these capabilities it transparently falls back to Go's
 standard implementations. This happens automatically at startup and
 works across different architectures.

--- a/blake3c/blake3c.go
+++ b/blake3c/blake3c.go
@@ -1,4 +1,4 @@
-//go:build cgo && (amd64 || arm64 || arm)
+//go:build cgo && (amd64 || arm64)
 
 package blake3c
 
@@ -6,7 +6,6 @@ package blake3c
 #cgo CFLAGS: -O3 -std=c99 -fno-stack-protector -fPIC
 #cgo amd64 CFLAGS: -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512
 #cgo arm64 CFLAGS: -DBLAKE3_USE_NEON
-#cgo arm CFLAGS: -DBLAKE3_USE_NEON -march=armv7-a -mfpu=neon
 #include "blake3.h"
 #include "blake3_impl.h"
 #include "lib/blake3.c"

--- a/blake3c/blake3c_stub.go
+++ b/blake3c/blake3c_stub.go
@@ -1,4 +1,4 @@
-//go:build !cgo || (!amd64 && !arm64 && !arm)
+//go:build !cgo || (!amd64 && !arm64)
 
 package blake3c
 

--- a/cpu_opt.go
+++ b/cpu_opt.go
@@ -29,7 +29,7 @@ func init() {
 		} else {
 			useStdSHA256 = true
 		}
-	case "arm64", "arm":
+	case "arm64":
 		if cpuid.CPU.Supports(cpuid.ASIMD) {
 			useBlake3C = true
 			useWyhashC = true
@@ -37,6 +37,8 @@ func init() {
 		} else {
 			useStdSHA256 = true
 		}
+	case "arm":
+		useStdSHA256 = true
 	default:
 		// Unknown architecture, use conservative default
 		useStdSHA256 = true

--- a/main.go
+++ b/main.go
@@ -84,7 +84,8 @@ func main() {
 }
 
 func generateChecksums(dir, output string, progress, jsonOut bool, algo string) error {
-	processed := map[string]bool{}
+        start := time.Now()
+        processed := map[string]bool{}
 	toFile := output != ""
 	var file *os.File
 	var writer *bufio.Writer
@@ -210,18 +211,22 @@ func generateChecksums(dir, output string, progress, jsonOut bool, algo string) 
 		file.Sync()
 	}
 	mu.Unlock()
-	if ticker != nil {
-		ticker.Stop()
-		fmt.Printf("%d/%d\n", processedCount, total)
-	}
-	return nil
+        if ticker != nil {
+                ticker.Stop()
+                fmt.Printf("%d/%d\n", processedCount, total)
+        }
+        if progress {
+                fmt.Printf("Time elapsed: %s\n", time.Since(start).Round(time.Second))
+        }
+        return nil
 }
 
 func verifyChecksums(dir, listfile string, verbose, progress, jsonIn bool, algo string) error {
-	type entry struct {
-		hash string
-		path string
-	}
+        start := time.Now()
+        type entry struct {
+                hash string
+                path string
+        }
 	var entries []entry
 
 	f, err := os.Open(listfile)
@@ -386,8 +391,11 @@ func verifyChecksums(dir, listfile string, verbose, progress, jsonIn bool, algo 
 			fmt.Println("All files match")
 		}
 	}
-	fmt.Printf("Total:%d Match:%d Mismatch:%d\n", total, match, mismatch)
-	return nil
+        fmt.Printf("Total:%d Match:%d Mismatch:%d\n", total, match, mismatch)
+        if progress {
+                fmt.Printf("Time elapsed: %s\n", time.Since(start).Round(time.Second))
+        }
+        return nil
 }
 
 func hashFile(path, algo string) (string, error) {

--- a/rapidhashc/rapidhashc.go
+++ b/rapidhashc/rapidhashc.go
@@ -1,4 +1,4 @@
-//go:build cgo && (amd64 || arm64 || arm)
+//go:build cgo && (amd64 || arm64)
 
 package rapidhashc
 
@@ -6,7 +6,6 @@ package rapidhashc
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
 #cgo arm64 CFLAGS:
-#cgo arm CFLAGS: -march=armv7-a -mfpu=neon
 #include "rapidhash.h"
 
 static inline uint64_t rapidhash_go(const void* data, size_t len) {

--- a/rapidhashc/rapidhashc_stub.go
+++ b/rapidhashc/rapidhashc_stub.go
@@ -1,4 +1,4 @@
-//go:build !cgo || (!amd64 && !arm64 && !arm)
+//go:build !cgo || (!amd64 && !arm64)
 
 package rapidhashc
 

--- a/t1ha/t1ha.go
+++ b/t1ha/t1ha.go
@@ -1,3 +1,5 @@
+//go:build cgo && (amd64 || arm64)
+
 package t1ha
 
 /*

--- a/t1ha/t1ha_stub.go
+++ b/t1ha/t1ha_stub.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo || (!amd64 && !arm64)
 
 package t1ha
 

--- a/wyhashc/wyhashc.go
+++ b/wyhashc/wyhashc.go
@@ -1,4 +1,4 @@
-//go:build cgo && (amd64 || arm64 || arm)
+//go:build cgo && (amd64 || arm64)
 
 package wyhashc
 
@@ -6,7 +6,6 @@ package wyhashc
 #cgo CFLAGS: -O3 -std=c99 -fPIC
 #cgo amd64 CFLAGS: -msse2
 #cgo arm64 CFLAGS:
-#cgo arm CFLAGS: -march=armv7-a -mfpu=neon
 #include "wyhash.h"
 
 static inline uint64_t wyhash_go(const void* data, size_t len) {

--- a/wyhashc/wyhashc_stub.go
+++ b/wyhashc/wyhashc_stub.go
@@ -1,4 +1,4 @@
-//go:build !cgo || (!amd64 && !arm64 && !arm)
+//go:build !cgo || (!amd64 && !arm64)
 
 package wyhashc
 


### PR DESCRIPTION
## Summary
- measure runtime when generating or verifying checksums
- display elapsed time at end when `-progress` flag is used
- document that armv7 builds use pure Go fallbacks and exclude cgo hash backends

## Testing
- `go vet ./...`
- `go build ./...`
- `GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build ./...`
- `GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab21c157308328b8459e61b717f2ea