### PR TITLE
Fix Windows ARM64 cgo flags

### DIFF
--- a/blake3c/blake3c.go
+++ b/blake3c/blake3c.go
@@ -1,9 +1,10 @@
-//go:build cgo && (amd64 || arm64)
+//go:build cgo && !arm
 
 package blake3c
 
 /*
-#cgo CFLAGS: -O3 -std=c99 -fno-stack-protector -fPIC
+#cgo CFLAGS: -O3 -std=c99
+#cgo !windows CFLAGS: -fno-stack-protector -fPIC
 #cgo amd64 CFLAGS: -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512
 #cgo arm64 CFLAGS: -DBLAKE3_USE_NEON
 #include "blake3.h"

--- a/rapidhashc/rapidhashc.go
+++ b/rapidhashc/rapidhashc.go
@@ -1,10 +1,12 @@
-//go:build cgo && (amd64 || arm64)
+//go:build cgo && !arm
 
 package rapidhashc
 
 /*
-#cgo CFLAGS: -O3 -std=c99 -fPIC
+#cgo CFLAGS: -O3 -std=c99
+#cgo !windows CFLAGS: -fPIC
 #cgo amd64 CFLAGS: -msse2
+#cgo 386 CFLAGS: -msse2
 #cgo arm64 CFLAGS:
 #include "rapidhash.h"
 

--- a/t1ha/t1ha.go
+++ b/t1ha/t1ha.go
@@ -1,9 +1,10 @@
-//go:build cgo && (amd64 || arm64)
+//go:build cgo && !arm
 
 package t1ha
 
 /*
-#cgo CFLAGS: -O3 -std=c11 -fno-stack-protector -fPIC
+#cgo CFLAGS: -O3 -std=c11
+#cgo !windows CFLAGS: -fno-stack-protector -fPIC
 #cgo LDFLAGS:
 #include <stdint.h>
 #include "t1ha.h"

--- a/wyhashc/wyhashc.go
+++ b/wyhashc/wyhashc.go
@@ -1,10 +1,12 @@
-//go:build cgo && (amd64 || arm64)
+//go:build cgo && !arm
 
 package wyhashc
 
 /*
-#cgo CFLAGS: -O3 -std=c99 -fPIC
+#cgo CFLAGS: -O3 -std=c99
+#cgo !windows CFLAGS: -fPIC
 #cgo amd64 CFLAGS: -msse2
+#cgo 386 CFLAGS: -msse2
 #cgo arm64 CFLAGS:
 #include "wyhash.h"
 


### PR DESCRIPTION
## Summary
- avoid using `-fPIC` and `-fno-stack-protector` on Windows
- allow building blake3, t1ha, rapidhash, and wyhash C implementations on all non-ARMv7 architectures
- add SSE2 flags for 386 to support C backends on x86

## Testing
- `go build ./... && echo build-ok`
- `GOOS=windows GOARCH=arm64 CGO_ENABLED=1 CC="zig cc -target aarch64-windows-gnu" go build ./...` *(fails: c compiler "zig" not found)*
- `GOOS=windows GOARCH=386 CGO_ENABLED=1 CC="zig cc -target i386-windows-gnu" go build ./...` *(fails: c compiler "zig" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab29a9e7cc8328895376482d7fa7a9