### PR TITLE
fix: update setup-zig action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           go-version: '1.23.x'
       - name: Set up Zig
-        uses: mlugg/setup-zig@v2.0.4
+        uses: mlugg/setup-zig@v2.0.5
       - name: Build binary
         run: |
           NAME=CheckSumFolder-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
## Summary
- update setup-zig to 2.0.5 to support Zig 0.15 env output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab2e4186e88328ba58407bc61e883f