### PR TITLE
Add NEON target feature for ARM builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,18 @@ jobs:
         uses: mlugg/setup-zig@v2.0.5
       - name: Build binary
         run: |
+          case "${{ matrix.goarch }}" in
+            amd64|386)
+              export RUSTFLAGS="-C target-feature=+aes,+sse2"
+              ;;
+            arm64|arm)
+              export RUSTFLAGS="-C target-feature=+aes,+neon"
+              ;;
+            *)
+              unset RUSTFLAGS
+              ;;
+          esac
+
           NAME=CheckSumFolder-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}
           if [ -n "${{ matrix.alias }}" ]; then
             NAME=CheckSumFolder-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.alias }}


### PR DESCRIPTION
## Summary
- set `RUSTFLAGS` dynamically in release workflow
- enable `+neon` for arm targets while keeping `+aes,+sse2` for x86

## Testing
- `RUSTFLAGS="-C target-feature=+aes,+sse2" go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba23103f948328a6572afbc2a0e51c