### PR TITLE
Add MD5 hash algorithm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CheckSumFolder -dir /path/to/dir [-list hashes.txt] [-hash sha256]
 If `-list` is omitted the results are printed to the console. When a file is
 specified and it already contains results, existing entries are skipped so the
 operation can be resumed. Use `-hash` to select the hashing algorithm. Allowed
-values are `sha1`, `sha256`, `blake2b`, `blake3`, `xxhash`, `xxh3`, `xxh128`, `t1ha1`, `t1ha2`, `highway64`, `highway128`, `highway256`, `wyhash` and `rapidhash`.
+values are `md5`, `sha1`, `sha256`, `blake2b`, `blake3`, `xxhash`, `xxh3`, `xxh128`, `t1ha1`, `t1ha2`, `highway64`, `highway128`, `highway256`, `wyhash` and `rapidhash`.
 When using a HighwayHash variant you can provide a custom key via the `-hkey`
 flag. The key must be 32 bytes encoded as hex or base64. If omitted the
 default key `AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=` (base64) is used.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/md5"
 	"crypto/sha1"
 	stdsha256 "crypto/sha256"
 	"encoding/base64"
@@ -52,7 +53,7 @@ func main() {
 	progress := flag.Bool("progress", false, "show progress updates")
 	jsonl := flag.Bool("json", false, "output in JSONL format")
 	hkeyFlag := flag.String("hkey", defaultHighwayKey, "hex or base64 HighwayHash key")
-	algo := flag.String("hash", "sha1", "hash algorithm: sha1|sha256|blake2b|blake3|xxhash|xxh3|xxh128|t1ha1|t1ha2|highway64|highway128|highway256|wyhash|rapidhash")
+	algo := flag.String("hash", "sha1", "hash algorithm: md5|sha1|sha256|blake2b|blake3|xxhash|xxh3|xxh128|t1ha1|t1ha2|highway64|highway128|highway256|wyhash|rapidhash")
 	flag.Parse()
 
 	if k, err := hex.DecodeString(*hkeyFlag); err == nil {
@@ -427,6 +428,8 @@ func hashFile(path, algo string) (string, error) {
 
 	var h hash.Hash
 	switch alg {
+	case "md5":
+		h = md5.New()
 	case "sha1":
 		h = sha1.New()
 	case "sha256":


### PR DESCRIPTION
## Summary
This PR adds MD5 hash algorithm support to the ChecksumFolder application.

## Changes Made
- **Added MD5 import**: Added `crypto/md5` import to main.go
- **Updated flag help**: Updated the `-hash` flag help text to include `md5` as an available option
- **Added MD5 case**: Added `md5` case to the `hashFile` function switch statement
- **Updated documentation**: Updated README.md to document MD5 support in the list of available algorithms

## Testing
- ✅ Built the application successfully with Go 1.23.8
- ✅ Tested MD5 hash generation on sample files
- ✅ Verified MD5 hashes match system `md5sum` output
- ✅ Tested verification functionality with MD5 hashes
- ✅ Tested JSON output format with MD5
- ✅ Confirmed existing SHA1 functionality still works correctly
- ✅ Verified help output shows MD5 in the list of supported algorithms

## Usage
Users can now use MD5 hashing with:
```bash
CheckSumFolder -dir /path/to/dir -hash md5
```

MD5 is now available alongside the existing hash algorithms: `md5`, `sha1`, `sha256`, `blake2b`, `blake3`, `xxhash`, `xxh3`, `xxh128`, `t1ha1`, `t1ha2`, `highway64`, `highway128`, `highway256`, `wyhash`, and `rapidhash`.

## Backward Compatibility
This change is fully backward compatible. All existing functionality remains unchanged, and MD5 is simply added as an additional option.

@dibu28 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/97d1b8264c8d4d4ca14fc8aad26444b5)